### PR TITLE
CORE-145: Add optional 'implements' argument to Registry.get_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
 - Add optional var-positional `implements` parameter to `Registry.get_all`.
 
 ## [0.2.0] - 2020-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Add optional var-positional `implements` parameter to `Registry.get_all`.
+
 ## [0.2.0] - 2020-08-03
 ### Added
 - Add support for django-oauth-toolkit >= 1.3.0

--- a/drf_integrations/integrations/registry.py
+++ b/drf_integrations/integrations/registry.py
@@ -30,6 +30,8 @@ class Registry:
         """
         Get all integrations. If `implements` is provided, only return integrations
         that are instances of **all** of the classes in `implements`.
+
+        :raises TypeError: If any element of implements is not a type.
         """
         if is_local is not None:
             integrations = {

--- a/drf_integrations/integrations/registry.py
+++ b/drf_integrations/integrations/registry.py
@@ -1,10 +1,11 @@
 import inspect
-from typing import Dict, List, Optional, Set, Type, Union
+from typing import Dict, Iterable, List, Optional, Set, Type, Union
 
 from django.urls import include, path
 
 from drf_integrations.exceptions import ImproperlyConfigured
 from drf_integrations.integrations.base import BaseIntegration
+from drf_integrations.utils import is_instance_of_all
 
 
 class Registry:
@@ -23,11 +24,26 @@ class Registry:
         self.integrations[integration_cls.name] = integration_cls(**kwargs)
         return self.integrations[integration_cls.name]
 
-    def get_all(self, *, is_local: Optional[bool] = None) -> Set[BaseIntegration]:
-        """Get all integrations."""
+    def get_all(
+        self, *implements: Iterable[type], is_local: Optional[bool] = None
+    ) -> Set[BaseIntegration]:
+        """
+        Get all integrations. If `implements` is provided, only return integrations
+        that are instances of **all** of the classes in `implements`.
+        """
         if is_local is not None:
-            return {value for value in self.integrations.values() if value.is_local is is_local}
-        return set(self.integrations.values())
+            integrations = {
+                value for value in self.integrations.values() if value.is_local is is_local
+            }
+        else:
+            integrations = set(self.integrations.values())
+
+        # Filter by implements
+        return set(
+            integration
+            for integration in integrations
+            if is_instance_of_all(integration, implements)
+        )
 
     def get(self, name_or_class: Union[str, Type[BaseIntegration]]) -> BaseIntegration:
         """

--- a/drf_integrations/integrations/registry.py
+++ b/drf_integrations/integrations/registry.py
@@ -28,10 +28,10 @@ class Registry:
         self, *implements: Iterable[type], is_local: Optional[bool] = None
     ) -> Set[BaseIntegration]:
         """
-        Get all integrations. If `implements` is provided, only return integrations
-        that are instances of **all** of the classes in `implements`.
+        Get all integrations. If ``implements`` is provided, only return integrations
+        that are instances of **all** of the classes in ``implements``.
 
-        :raises TypeError: If any element of implements is not a type.
+        :raises TypeError: If any element of ``implements`` is not a type.
         """
         if is_local is not None:
             integrations = {

--- a/drf_integrations/utils.py
+++ b/drf_integrations/utils.py
@@ -47,8 +47,8 @@ def iter_split_string(string: Optional[AnyString], separator: str = ",") -> Iter
 
 def is_instance_of_all(obj, classes: Iterable[type]) -> bool:
     """
-    Returns `True` if the *obj* argument is an instance of all of the
-    classes in the *classes* argument.
+    Returns ``True`` if the ``obj`` argument is an instance of all of the
+    classes in the ``classes`` argument.
 
     :raises TypeError: If any element of classes is not a type.
     """

--- a/drf_integrations/utils.py
+++ b/drf_integrations/utils.py
@@ -49,5 +49,9 @@ def is_instance_of_all(obj, classes: Iterable[type]) -> bool:
     """
     Returns `True` if the *obj* argument is an instance of all of the
     classes in the *classes* argument.
+
+    :raises TypeError: If any element of classes is not a type.
     """
+    if any(not isinstance(classinfo, type) for classinfo in classes):
+        raise TypeError("classes must contain types")
     return all(isinstance(obj, classinfo) for classinfo in classes)

--- a/drf_integrations/utils.py
+++ b/drf_integrations/utils.py
@@ -47,7 +47,7 @@ def iter_split_string(string: Optional[AnyString], separator: str = ",") -> Iter
 
 def is_instance_of_all(obj, classes: Iterable[type]) -> bool:
     """
-    Returns `True` if the *object* arugment is an instance of all of the
+    Returns `True` if the *obj* argument is an instance of all of the
     classes in the *classes* argument.
     """
     return all(isinstance(obj, classinfo) for classinfo in classes)

--- a/drf_integrations/utils.py
+++ b/drf_integrations/utils.py
@@ -43,3 +43,11 @@ def iter_split_string(string: Optional[AnyString], separator: str = ",") -> Iter
 
     else:
         raise TypeError("Cannot split string of {!r}".format(type(string)))
+
+
+def is_instance_of_all(obj, classes: Iterable[type]) -> bool:
+    """
+    Returns `True` if the *object* arugment is an instance of all of the
+    classes in the *classes* argument.
+    """
+    return all(isinstance(obj, classinfo) for classinfo in classes)

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -52,8 +52,8 @@ def test_get_all(get_integration):
 
 def test_get_all_with_implements(get_integration):
     """
-    Calling get_all with `implements` correctly returns all, local or non-local
-    integration sets that inherit from all the classes in `implements`.
+    Calling ``get_all`` with ``implements`` correctly returns all, local or non-local
+    integration sets that inherit from all the classes in ``implements``.
     """
     registry = Registry()
     integration1 = get_integration(is_local=True, register=False)

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -63,6 +63,8 @@ def test_get_all_with_implements(get_integration):
     assert registry.get_all(TestLocalIntegration) == {integration1()}
     assert registry.get_all(TestInternalIntegration) == {integration2()}
     assert registry.get_all(TestInternalIntegration, TestLocalIntegration) == set()
+    with pytest.raises(TypeError):
+        registry.get_all(integration2())
 
 
 def test_get_urls():

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -4,6 +4,7 @@ from django.urls.resolvers import RegexPattern
 
 from drf_integrations.integrations import Registry
 from drf_integrations.integrations.base import BaseIntegration
+from tests.integration_samples import TestInternalIntegration, TestLocalIntegration
 
 
 def test_register(get_integration):
@@ -47,6 +48,21 @@ def test_get_all(get_integration):
     assert registry.get_all() == {integration1(), integration2()}
     assert registry.get_all(is_local=True) == {integration1()}
     assert registry.get_all(is_local=False) == {integration2()}
+
+
+def test_get_all_with_implements(get_integration):
+    """
+    Calling get_all with `implements` correctly returns all, local or non-local
+    integration sets that inherit from all the classes in `implements`.
+    """
+    registry = Registry()
+    integration1 = get_integration(is_local=True, register=False)
+    registry.register(integration1)
+    integration2 = get_integration(is_local=False, register=False)
+    registry.register(integration2)
+    assert registry.get_all(TestLocalIntegration) == {integration1()}
+    assert registry.get_all(TestInternalIntegration) == {integration2()}
+    assert registry.get_all(TestInternalIntegration, TestLocalIntegration) == set()
 
 
 def test_get_urls():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,3 +29,10 @@ def test_iter_split_string(values):
 )
 def test_split_string(values):
     assert utils.split_string(values) == ["0", "1", "2", "3", "4"]
+
+
+@pytest.mark.parametrize(
+    "obj,classes,expected", [(1, [int], True), (1, [int, str], False), (1, [], True)],
+)
+def test_is_instance_of_all(obj, classes, expected):
+    assert utils.is_instance_of_all(obj, classes) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from contextlib import ExitStack as does_not_raise
+
 import pytest
 
 from drf_integrations import utils
@@ -32,7 +34,14 @@ def test_split_string(values):
 
 
 @pytest.mark.parametrize(
-    "obj,classes,expected", [(1, [int], True), (1, [int, str], False), (1, [], True)],
+    "obj,classes,expected,expectation",
+    [
+        (1, [int], True, does_not_raise()),
+        (1, [int, str], False, does_not_raise()),
+        (1, [], True, does_not_raise()),
+        (1, [1], False, pytest.raises(TypeError)),
+    ],
 )
-def test_is_instance_of_all(obj, classes, expected):
-    assert utils.is_instance_of_all(obj, classes) == expected
+def test_is_instance_of_all(obj, classes, expected, expectation):
+    with expectation:
+        assert utils.is_instance_of_all(obj, classes) == expected


### PR DESCRIPTION
Adds an optional 'implements' argument to `Registry.get_all`. `implements` allows you to filter integrations by the classes they implement.