### PR TITLE
CORE-146: Accept keyword arguments for integration request lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add var-keyword argument `**kwargs` to `BaseIntegration.get_installation_lookup_from_request`
 
 ## Changed
-- Make the `application` argument of `BaseIntegration.get_installation_lookup_from_request` keyword-only.
+- Change the `application` argument of `BaseIntegration.get_installation_lookup_from_request` to be keyword-only.
 
 
 ## [0.2.0] - 2020-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## Added
 - Add optional var-positional `implements` parameter to `Registry.get_all`.
+- Add var-keyword argument `**kwargs` to `BaseIntegration.get_installation_lookup_from_request`
+
+## Changed
+- Make the `application` argument of `BaseIntegration.get_installation_lookup_from_request` keyword-only.
+
 
 ## [0.2.0] - 2020-08-03
 ### Added

--- a/drf_integrations/integrations/base.py
+++ b/drf_integrations/integrations/base.py
@@ -215,7 +215,7 @@ class BaseIntegration:
 
     @classmethod
     def get_installation_lookup_from_request(
-        cls, request: "Request", application: "Optional[models.Application]" = None
+        cls, request: "Request", application: "Optional[models.Application]" = None, **kwargs
     ) -> Dict:
         """
         Return a lookup filter suitable for models that subclass

--- a/drf_integrations/integrations/base.py
+++ b/drf_integrations/integrations/base.py
@@ -215,7 +215,7 @@ class BaseIntegration:
 
     @classmethod
     def get_installation_lookup_from_request(
-        cls, request: "Request", application: "Optional[models.Application]" = None, **kwargs
+        cls, request: "Request", *, application: "Optional[models.Application]" = None, **kwargs
     ) -> Dict:
         """
         Return a lookup filter suitable for models that subclass


### PR DESCRIPTION
Add var-keyword argument `**kwargs` to `BaseIntegration.get_installation_lookup_from_request` and make the `application` argument keyword-only.