### PR TITLE
Perform check for unbound installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ between the source/destiny of events, how these requests are authenticated and t
 ## Installation
 Install using `pip` (coming soon to PyPI):
 ```bash
-pip install https://github.com/yoyowallet/drf-integrations-framework/archive/0.3.0.tar.gz
+pip install https://github.com/yoyowallet/drf-integrations-framework/archive/0.3.1.tar.gz
 ```
 
 Add the apps to your `INSTALLED_APPS`:

--- a/drf_integrations/__init__.py
+++ b/drf_integrations/__init__.py
@@ -1,3 +1,3 @@
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 
 default_app_config = "drf_integrations.apps.DRFIntegrationsConfig"

--- a/drf_integrations/models.py
+++ b/drf_integrations/models.py
@@ -275,10 +275,22 @@ def _get_application_installation_class():
         objects = managers.ApplicationInstallationQuerySet.as_manager()
 
         def __str__(self):
-            return (
-                f"{self.application.get_integration_instance().name} installation for "
-                f"{getattr(self, get_application_installation_install_attribute_name())}"
+            try:
+                associated_app_integration = self.application.get_integration_instance()
+            except ValueError:
+                associated_app_integration = None
+
+            install_attribute_name = getattr(
+                self, get_application_installation_install_attribute_name()
             )
+
+            if associated_app_integration:
+                return (
+                    f"{associated_app_integration.name} installation for "
+                    f"{install_attribute_name}"
+                )
+
+            return f"installation for {install_attribute_name} without integration"
 
         def get_config(self) -> Dict:
             return self.config or {}

--- a/drf_integrations/models.py
+++ b/drf_integrations/models.py
@@ -290,7 +290,7 @@ def _get_application_installation_class():
                     f"{install_attribute_name}"
                 )
 
-            return f"installation for {install_attribute_name} without integration"
+            return f"installation for {install_attribute_name} without valid integration"
 
         def get_config(self) -> Dict:
             return self.config or {}


### PR DESCRIPTION
Description
-
Fixes the `__str__` method of `ApplicationInstallation` which throws `ValueError` whenever the associated application does not have a bound integration.

Preview
-
In this image Devclever does not have a bound integration

![image](https://user-images.githubusercontent.com/4908719/91339895-c12ba980-e79c-11ea-9ed9-bccfd16eb7cf.png)
