### PR TITLE
Define namespace property on BaseIntegration class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add `namespace` property to `BaseIntegration` class.
+
 ## [0.3.0] - 2020-08-14
 ### Added
 - Add optional var-positional `implements` parameter to `Registry.get_all`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2020-09-08
 ### Added
 - Add `namespace` property to `BaseIntegration` class.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ between the source/destiny of events, how these requests are authenticated and t
 ## Installation
 Install using `pip` (coming soon to PyPI):
 ```bash
-pip install https://github.com/yoyowallet/drf-integrations-framework/archive/0.3.0.tar.gz
+pip install https://github.com/yoyowallet/drf-integrations-framework/archive/0.4.0.tar.gz
 ```
 
 Add the apps to your `INSTALLED_APPS`:

--- a/drf_integrations/__init__.py
+++ b/drf_integrations/__init__.py
@@ -1,3 +1,3 @@
-VERSION = "0.3.0"
+VERSION = "0.4.0"
 
 default_app_config = "drf_integrations.apps.DRFIntegrationsConfig"

--- a/drf_integrations/integrations/base.py
+++ b/drf_integrations/integrations/base.py
@@ -149,6 +149,13 @@ class BaseIntegration:
         return self.name
 
     @property
+    def namespace(self) -> str:
+        """
+        The URL namespace in which URLs for this integration should be included.
+        """
+        return f"integration-{self.name}"
+
+    @property
     def default_scopes(self) -> List[str]:
         """
         List of default scopes for the integration, if any.

--- a/drf_integrations/integrations/registry.py
+++ b/drf_integrations/integrations/registry.py
@@ -74,11 +74,13 @@ class Registry:
             # Integration URLs
             integration_urls = integration_cls.get_urls()
             if integration_urls:
-                namespace = f"integration-{name}"
                 urls += [
                     path(
                         f"{basepath}{name}/",
-                        include((integration_urls, namespace), namespace=namespace),
+                        include(
+                            (integration_urls, integration_cls.namespace),
+                            namespace=integration_cls.namespace,
+                        ),
                     )
                 ]
         return urls


### PR DESCRIPTION
Define `namespace` property on `BaseIntegration` class that we can use to reverse a URL for an integration. Like [here](https://github.com/yoyowallet/platform/pull/4016/commits/cd0e8e0efe393eafbae6a0cccd652b89bb06fe68#diff-0baa3f0631d74826b2d653439d62a36dR394-R395) for example.