### PR TITLE
Support installations without integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.6.0] - 2021-04-12
+### Changed
+- Allow an `Application` to be standalone without an integration to allow direct usage of the `ApplicationInstallation` config field.
+
 ## [0.5.0] - 2021-01-27
 ### Added
 - Allow an `ApplicationInstallation` model object's `config` field to be [`blank`](https://docs.djangoproject.com/en/3.0/ref/models/fields/#blank).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ between the source/destiny of events, how these requests are authenticated and t
 ## Installation
 Install using `pip` (coming soon to PyPI):
 ```bash
-pip install https://github.com/yoyowallet/drf-integrations-framework/archive/0.5.0.tar.gz
+pip install https://github.com/yoyowallet/drf-integrations-framework/archive/0.6.0.tar.gz
 ```
 
 Add the apps to your `INSTALLED_APPS`:

--- a/drf_integrations/__init__.py
+++ b/drf_integrations/__init__.py
@@ -1,3 +1,3 @@
-VERSION = "0.5.0"
+VERSION = "0.6.0"
 
 default_app_config = "drf_integrations.apps.DRFIntegrationsConfig"

--- a/drf_integrations/forms.py
+++ b/drf_integrations/forms.py
@@ -36,6 +36,9 @@ class ApplicationInstallationForm(forms.ModelForm):
 
         config = self.instance.get_config()
 
+        # An empty string means default api_client_name. Since django treats null and
+        # blank equally any null values are rendered as default api_client_name. To get
+        # around this we add an option to be used as null.
         self.fields['api_client_name'].choices = [('-', '-')] + self.fields['api_client_name'].choices
 
         if self.initial.get('api_client_name') is None:
@@ -57,6 +60,9 @@ class ApplicationInstallationForm(forms.ModelForm):
     def clean(self):
         # Clean turns '' into None
         is_default = self.data['api_client_name'] == ''
+        # Incoming empty string values are transformed to None by the clean method.
+        # Thus we track if we have an incoming empty string for the default
+        # api_client_name and restore the value after clean.
         data = super().clean()
 
         if data['api_client_name'] == '-':

--- a/drf_integrations/forms.py
+++ b/drf_integrations/forms.py
@@ -1,7 +1,7 @@
 import copy
 
 from django import forms
-
+from django.contrib.postgres.forms.jsonb import JSONField
 from drf_integrations import models
 from drf_integrations.integrations import Registry
 
@@ -17,6 +17,7 @@ class ApplicationInstallationForm(forms.ModelForm):
         fields = [
             "application",
             models.get_application_installation_install_attribute_name(),
+            "api_client_name",
         ]
 
     def __init__(self, data=None, *args, **kwargs):
@@ -33,17 +34,35 @@ class ApplicationInstallationForm(forms.ModelForm):
             except Registry.IntegrationUnavailableException:
                 pass
 
+        config = self.instance.get_config()
+
+        self.fields['api_client_name'].choices = [('-', '-')] + self.fields['api_client_name'].choices
+
+        if self.initial.get('api_client_name') is None:
+            self.initial['api_client_name'] = '-'
+
         if use_config_class:
-            config = self.instance.get_config()
             integration_class = self.instance.application.get_integration_instance()
             self.integration_form = integration_class.config_form_class
             for name, field in self.integration_form.base_fields.items():
                 self.integration_config_fields.append(name)
                 self.fields[name] = field
                 self.initial[name] = config.get(name, field.initial)
+        else:
+            # Application has no integration
+            # Render config field
+            self.fields['config'] = JSONField()
+            self.initial['config'] = config
 
     def clean(self):
+        # Clean turns '' into None
+        is_default = self.data['api_client_name'] == ''
         data = super().clean()
+
+        if data['api_client_name'] == '-':
+            data['api_client_name'] = None
+        elif is_default:
+            data['api_client_name'] = ''
 
         if self.integration_form:
             data = self.integration_form.clean_form_data(self)
@@ -51,8 +70,13 @@ class ApplicationInstallationForm(forms.ModelForm):
         return data
 
     def save(self, commit=True):
-        self.instance.config = {
-            name: self.cleaned_data.get(name) for name in self.integration_config_fields
-        }
+        if self.integration_form:
+            self.instance.config = {
+                name: self.cleaned_data.get(name) for name in self.integration_config_fields
+            }
+        else:
+            self.instance.config = self.cleaned_data.get('config', {})
 
         return super().save(commit)
+
+

--- a/drf_integrations/forms.py
+++ b/drf_integrations/forms.py
@@ -2,6 +2,7 @@ import copy
 
 from django import forms
 from django.contrib.postgres.forms.jsonb import JSONField
+
 from drf_integrations import models
 from drf_integrations.integrations import Registry
 
@@ -39,10 +40,12 @@ class ApplicationInstallationForm(forms.ModelForm):
         # An empty string means default api_client_name. Since django treats null and
         # blank equally any null values are rendered as default api_client_name. To get
         # around this we add an option to be used as null.
-        self.fields['api_client_name'].choices = [('-', '-')] + self.fields['api_client_name'].choices
+        self.fields["api_client_name"].choices = [("-", "-")] + self.fields[
+            "api_client_name"
+        ].choices
 
-        if self.initial.get('api_client_name') is None:
-            self.initial['api_client_name'] = '-'
+        if self.initial.get("api_client_name") is None:
+            self.initial["api_client_name"] = "-"
 
         if use_config_class:
             integration_class = self.instance.application.get_integration_instance()
@@ -51,24 +54,25 @@ class ApplicationInstallationForm(forms.ModelForm):
                 self.integration_config_fields.append(name)
                 self.fields[name] = field
                 self.initial[name] = config.get(name, field.initial)
+
         else:
             # Application has no integration
             # Render config field
-            self.fields['config'] = JSONField()
-            self.initial['config'] = config
+            self.fields["config"] = JSONField()
+            self.initial["config"] = config
 
     def clean(self):
         # Clean turns '' into None
-        is_default = self.data['api_client_name'] == ''
+        is_default = self.data["api_client_name"] == ""
         # Incoming empty string values are transformed to None by the clean method.
         # Thus we track if we have an incoming empty string for the default
         # api_client_name and restore the value after clean.
         data = super().clean()
 
-        if data['api_client_name'] == '-':
-            data['api_client_name'] = None
+        if data["api_client_name"] == "-":
+            data["api_client_name"] = None
         elif is_default:
-            data['api_client_name'] = ''
+            data["api_client_name"] = ""
 
         if self.integration_form:
             data = self.integration_form.clean_form_data(self)
@@ -81,8 +85,6 @@ class ApplicationInstallationForm(forms.ModelForm):
                 name: self.cleaned_data.get(name) for name in self.integration_config_fields
             }
         else:
-            self.instance.config = self.cleaned_data.get('config', {})
+            self.instance.config = self.cleaned_data.get("config", {})
 
         return super().save(commit)
-
-

--- a/drf_integrations/forms.py
+++ b/drf_integrations/forms.py
@@ -62,11 +62,10 @@ class ApplicationInstallationForm(forms.ModelForm):
             self.initial["config"] = config
 
     def clean(self):
-        # Clean turns '' into None
-        is_default = self.data["api_client_name"] == ""
         # Incoming empty string values are transformed to None by the clean method.
         # Thus we track if we have an incoming empty string for the default
         # api_client_name and restore the value after clean.
+        is_default = self.data["api_client_name"] == ""
         data = super().clean()
 
         if data["api_client_name"] == "-":

--- a/drf_integrations/models.py
+++ b/drf_integrations/models.py
@@ -275,10 +275,16 @@ def _get_application_installation_class():
         objects = managers.ApplicationInstallationQuerySet.as_manager()
 
         def __str__(self):
-            return (
-                f"{self.application.get_integration_instance().name} installation for "
-                f"{getattr(self, get_application_installation_install_attribute_name())}"
-            )
+            try:
+                return (
+                    f"{self.application.get_integration_instance().name} installation for "
+                    f"{getattr(self, get_application_installation_install_attribute_name())}"
+                )
+            except ValueError:
+                return (
+                    f"Installation for "
+                    f"{getattr(self, get_application_installation_install_attribute_name())}"
+                )
 
         def get_config(self) -> Dict:
             return self.config or {}


### PR DESCRIPTION
Description
-
In case an Installation does not have an associated integration, don't dynamically populate the changeform of that instance to show the fields from `config` but rather show the `config` field as JSON for direct manipulation.