### PR TITLE
Fix JSONField issue

### DIFF
--- a/drf_integrations/fields.py
+++ b/drf_integrations/fields.py
@@ -1,5 +1,7 @@
 import csv
+import django
 import io
+import logging
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -10,14 +12,45 @@ from django.utils.translation import ugettext_lazy as _
 
 from drf_integrations.utils import split_string
 
+logger = logging.getLogger(__name__)
 
-def get_json_field():
+
+def get_json_model_field():
+    # if the Django version >= 3.2 then user the new default JSONField
+    if django.VERSION[0] >= 3 and django.VERSION[1] >= 2:
+        default = "django.db.models.JSONField"
+    else:
+        default = "django.contrib.postgres.fields.JSONField"
+
+    # Allow for override
+    model_field = getattr(settings, "DB_BACKEND_JSON_FIELD", default)
+    logger.info(f"Using django model JSONField: {model_field}")
     try:
-        return import_string(settings.DB_BACKEND_JSON_FIELD)
+        return import_string(model_field)
     except ImportError:
         raise ImportError(
             "drf_integrations can only work with a backend that supports JSON fields, "
             "please make sure you set the DB_BACKEND_JSON_FIELD setting to the "
+            "JSONField of your backend."
+        )
+
+
+def get_json_form_field():
+    # if the Django version >= 3.2 then user the new default JSONField
+    if django.VERSION[0] >= 3 and django.VERSION[1] >= 2:
+        default = "django.forms.JSONField"
+    else:
+        default = "django.contrib.postgres.forms.JSONField"
+
+    # Allow for override
+    form_field = getattr(settings, "DB_BACKEND_JSON_FORM_FIELD", default)
+    logger.info(f"Using django form JSONField: {form_field}")
+    try:
+        return import_string(form_field)
+    except ImportError:
+        raise ImportError(
+            "drf_integrations can only work with a backend that supports JSON fields, "
+            "please make sure you set the DB_BACKEND_JSON_FORM_FIELD setting to the "
             "JSONField of your backend."
         )
 

--- a/drf_integrations/forms.py
+++ b/drf_integrations/forms.py
@@ -1,8 +1,8 @@
 import copy
 from django import forms
-from django.contrib.postgres.forms import JSONField
 
 from drf_integrations import models
+from drf_integrations.fields import get_json_form_field
 from drf_integrations.integrations import Registry
 
 
@@ -57,7 +57,7 @@ class ApplicationInstallationForm(forms.ModelForm):
         else:
             # Application has no integration
             # Render config field
-            self.fields["config"] = JSONField(required=False)
+            self.fields["config"] = get_json_form_field()(required=False)
             self.initial["config"] = config
 
     def clean(self):

--- a/drf_integrations/forms.py
+++ b/drf_integrations/forms.py
@@ -1,11 +1,9 @@
 import copy
 from django import forms
+from django.contrib.postgres.forms import JSONField
 
 from drf_integrations import models
-from drf_integrations.fields import get_json_field
 from drf_integrations.integrations import Registry
-
-JSONField = get_json_field()
 
 
 class ApplicationInstallationForm(forms.ModelForm):

--- a/drf_integrations/migrations/0001_initial.py
+++ b/drf_integrations/migrations/0001_initial.py
@@ -6,10 +6,10 @@ import oauth2_provider.generators
 from django.conf import settings
 from django.db import migrations, models
 
-from drf_integrations.fields import get_json_field
+from drf_integrations.fields import get_json_model_field
 from drf_integrations.models import get_application_installation_install_attribute_name
 
-JSONField = get_json_field()
+JSONField = get_json_model_field()
 
 
 class Migration(migrations.Migration):

--- a/drf_integrations/migrations/0003_auto_20210118_1317.py
+++ b/drf_integrations/migrations/0003_auto_20210118_1317.py
@@ -2,9 +2,9 @@
 
 from django.db import migrations
 
-from drf_integrations.fields import get_json_field
+from drf_integrations.fields import get_json_model_field
 
-JSONField = get_json_field()
+JSONField = get_json_model_field()
 
 
 class Migration(migrations.Migration):

--- a/drf_integrations/models.py
+++ b/drf_integrations/models.py
@@ -17,10 +17,10 @@ from oauth2_provider.settings import oauth2_settings
 from uuid import uuid4
 
 from drf_integrations import managers
-from drf_integrations.fields import get_json_field
+from drf_integrations.fields import get_json_model_field
 from drf_integrations.types import IntegrationT
 
-JSONField = get_json_field()
+JSONField = get_json_model_field()
 
 if TYPE_CHECKING:
     from rest_framework.request import Request


### PR DESCRIPTION
An issue was found in Platform when upgrading the packages to the latest versions where the `drf integrations framework` was using models.JSONField instead of forms.JSONField and `JSONField(required=True)` was throwing an exception.

I edited the code locally under my site packages folder to test if this worked and it appears to fix the issue and the ApplicationInstallation Add admin page loaded correctly.